### PR TITLE
chore(deps): bump https://github.com/cheesydev-labs/jx-quickstart-go-app.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[cheesydev-labs/jx-quickstart-go-app](https://github.com/cheesydev-labs/jx-quickstart-go-app.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: cheesydev-labs
+  repo: jx-quickstart-go-app
+  url: https://github.com/cheesydev-labs/jx-quickstart-go-app.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/cheesydev-labs-jx-quickstart-go-app-sr.yaml
+++ b/repositories/templates/cheesydev-labs-jx-quickstart-go-app-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: cheesydev-labs
+    provider: github
+    repository: jx-quickstart-go-app
+  name: cheesydev-labs-jx-quickstart-go-app
+spec:
+  description: Imported application for cheesydev-labs/jx-quickstart-go-app
+  httpCloneURL: https://github.com/cheesydev-labs/jx-quickstart-go-app.git
+  org: cheesydev-labs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-quickstart-go-app
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/cheesydev-labs/jx-quickstart-go-app.git


### PR DESCRIPTION
Update [cheesydev-labs/jx-quickstart-go-app](https://github.com/cheesydev-labs/jx-quickstart-go-app.git) 

Command run was `jx create quickstart --git-public`